### PR TITLE
Closes #3 Hide escape sequence when using pipe

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"./sensu"
 	"fmt"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var version string
@@ -18,6 +20,10 @@ func main() {
 		expiration string
 		reason     string
 	)
+
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		sensu.EscapeSequence = false
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "ohgi",

--- a/sensu/functions.go
+++ b/sensu/functions.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+var EscapeSequence bool = true
+
 func utoa(timestamp int64) string {
 	format := "2006/01/02 15:04:05"
 	return time.Unix(timestamp, 0).Format(format)
@@ -47,6 +49,10 @@ func stoe(expiration string) int64 {
 }
 
 func bold(str string) string {
+	if !EscapeSequence {
+		return str
+	}
+
 	return "\x1b[1m" + str + "\x1b[0m"
 }
 
@@ -75,6 +81,19 @@ func httpStatus(status int) string {
 }
 
 func statusFg(status int) string {
+	if !EscapeSequence {
+		switch status {
+		case 0:
+			return "OK "
+		case 1:
+			return "WARNING "
+		case 2:
+			return "CRITICAL "
+		default:
+			return "UNKNOWN "
+		}
+	}
+
 	switch status {
 	case 0:
 		return "\x1b[32mOK\x1b[0m "
@@ -82,11 +101,16 @@ func statusFg(status int) string {
 		return "\x1b[33mWARNING\x1b[0m "
 	case 2:
 		return "\x1b[31mCRITICAL\x1b[0m "
+	default:
+		return "\x1b[37mUNKNOWN\x1b[0m "
 	}
-	return "\x1b[37mUNKNOWN\x1b[0m "
 }
 
 func statusBg(status int) string {
+	if !EscapeSequence {
+		return "  "
+	}
+
 	switch status {
 	case 0:
 		return "\x1b[42m \x1b[0m "


### PR DESCRIPTION
Fixed like this.

```
  CLIENT                                  CHECK                         #         TIMESTAMP
  sumaug_saience                          check-cpu                     10947     2015/03/07 10:46:12
  kanon                                   check-disk                    25833     2015/03/07 10:47:40
```
