### PR TITLE
Closes #5 Enable use of multiple datacenters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,27 @@
 `~/.ohgi.json`
 
     {
-      "host": "127.0.0.1",  // Required
-      "port": 4567,         // Required
-      "user": "",           // Optional
-      "password": "",       // Optional
-      "timeout": 3          // Optional
+      "datacenters": [
+        {
+          "name": "server-1",       // Required
+          "host": "192.168.11.10",  // Required
+          "port": 4567,             // Required
+          "user": "sensu-1",        // Optional
+          "password": "password"    // Optional
+        },
+        {
+          "name": "server-2",
+          "host": "192.168.11.20",
+          "port": 4567
+        }
+      ],
+      "timeout": 3                  // Optional
     }
+
+Specify a datacenter by `-x`(`--datacenter`) option as below.
+If datacenter is not specified, use first of `datacenters`.
+
+    $ ohgi -x server-1 events
 
 #### Usage
 
@@ -51,6 +66,7 @@
       help        Help about any command
     
     Flags:
+      -x, --datacenter="": Specify a datacenter
       -h, --help=false: help for ohgi
     
     Use "ohgi help [command]" for more information about a command.

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ var version string
 
 func main() {
 	var (
+		datacenter string
 		limit      int
 		offset     int
 		delete     bool
@@ -23,7 +24,6 @@ func main() {
 		reason     string
 	)
 
-	ohgi.LoadConfig()
 	if !isatty.IsTerminal(os.Stdout.Fd()) {
 		ohgi.EscapeSequence = false
 	}
@@ -32,7 +32,11 @@ func main() {
 		Use:   "ohgi",
 		Short: "Sensu command-line tool by golang",
 		Long:  "Sensu command-line tool by golang\nhttps://github.com/hico-horiuchi/ohgi",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			ohgi.LoadConfig(datacenter)
+		},
 	}
+	rootCmd.PersistentFlags().StringVarP(&datacenter, "datacenter", "x", "", "Specify a datacenter")
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "checks [check]",

--- a/ohgi/api.go
+++ b/ohgi/api.go
@@ -8,12 +8,12 @@ import (
 )
 
 func makeRequest(method string, namespace string, payload io.Reader) *http.Request {
-	url := "http://" + config.Host + ":" + strconv.Itoa(config.Port) + namespace
+	url := "http://" + datacenter.Host + ":" + strconv.Itoa(datacenter.Port) + namespace
 	request, err := http.NewRequest(method, url, payload)
 	checkError(err)
 
-	if config.User != "" && config.Password != "" {
-		request.SetBasicAuth(config.User, config.Password)
+	if datacenter.User != "" && datacenter.Password != "" {
+		request.SetBasicAuth(datacenter.User, datacenter.Password)
 	}
 
 	if payload != nil {

--- a/ohgi/config.go
+++ b/ohgi/config.go
@@ -2,30 +2,58 @@ package ohgi
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
 )
 
-var config configStruct
-var timeout = 1 * time.Second
+var datacenter dcStruct
+var timeout = 3 * time.Second
 
 type configStruct struct {
+	Datacenters []dcStruct
+	Timeout     int
+}
+
+type dcStruct struct {
+	Name     string
 	Host     string
 	Port     int
 	User     string
 	Password string
-	Timeout  int
 }
 
-func LoadConfig() {
+func LoadConfig(dc string) {
+	var c configStruct
+
 	bytes, err := ioutil.ReadFile(os.Getenv("HOME") + "/.ohgi.json")
 	checkError(err)
-	json.Unmarshal(bytes, &config)
 
-	if config.Timeout > 0 {
-		timeout = time.Duration(config.Timeout) * time.Second
+	json.Unmarshal(bytes, &c)
+	datacenter, err = c.selectDatacenter(dc)
+	checkError(err)
+
+	if c.Timeout > 0 {
+		timeout = time.Duration(c.Timeout) * time.Second
 	}
 	http.DefaultClient.Timeout = timeout
+}
+
+func (c configStruct) selectDatacenter(name string) (dcStruct, error) {
+	switch {
+	case len(c.Datacenters) < 1:
+		return dcStruct{}, errors.New("ohgi: no datacenters in config")
+	case name == "":
+		return c.Datacenters[0], nil
+	}
+
+	for _, dc := range c.Datacenters {
+		if dc.Name == name {
+			return dc, nil
+		}
+	}
+
+	return dcStruct{}, errors.New("ohgi: no such datacenter in config")
 }


### PR DESCRIPTION
`~/.sensu.json` to look like this.

```
{
  "datacenters": [
    {
      "name": "server-1",
      "host": "192.168.11.10",
      "port": 4567,
      "user": "sensu-1",
      "password": "password"
    },
    {
      "name": "server-2"
      "host": "192.168.11.20",
      "port": 4567,
      "user": "sensu-2",
      "password": "password"
    }
  ]
}
```

Specify datacenter by `-x`(`--datacenter`) option like this.
If datacenter isn't specified, use first of `datacenters`.

```
$ ohgi -x server-1 events
```
